### PR TITLE
4 feature api 반환 포맷 규격화

### DIFF
--- a/src/main/java/com/example/blog/controller/LoginController.java
+++ b/src/main/java/com/example/blog/controller/LoginController.java
@@ -2,7 +2,9 @@ package com.example.blog.controller;
 
 import com.example.blog.model.Member;
 import com.example.blog.repository.MemberRepository;
+import com.example.blog.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,16 +19,20 @@ public class LoginController {
     private final MemberRepository memberRepository;
 
     @PostMapping("/register")
-    ResponseEntity<Object> createMember(@RequestBody Member member) {
+    ResponseEntity<ApiResponse<Member>> createMember(@RequestBody Member member) {
         Member findMember = memberRepository.findByUsername(member.getUsername());
-        ResponseEntity<Object> response = null;
+        ResponseEntity<ApiResponse<Member>> response = null;
+        ApiResponse<Member> responseBody = null;
+
         if (findMember == null) {
             Member savedMember = memberRepository.save(member);
             String uriString = new StringBuilder().append("/members").append(savedMember.getId()).toString();
             URI location = URI.create(uriString);
-            response = ResponseEntity.created(location).body(savedMember);
+            responseBody = ApiResponse.createSuccessResponse(savedMember, HttpStatus.CREATED);
+            response = ResponseEntity.created(location).body(responseBody);
         } else {
-            response = ResponseEntity.badRequest().build();
+            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.BAD_REQUEST);
+            response = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
         }
 
         return response;

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -2,11 +2,12 @@ package com.example.blog.controller;
 
 import com.example.blog.model.Member;
 import com.example.blog.repository.MemberRepository;
+import com.example.blog.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -18,23 +19,28 @@ public class MemberController {
     private final MemberRepository memberRepository;
 
     @GetMapping("/members/{id}")
-    ResponseEntity<Object> findMemberById(@PathVariable("id") Long id) {
+    ResponseEntity<ApiResponse<Member>> findMemberById(@PathVariable("id") Long id) {
         Optional<Member> optionalMember = memberRepository.findById(id);
-        ResponseEntity<Object> response = null;
+        ResponseEntity<ApiResponse<Member>> response = null;
+        ApiResponse<Member> responseBody = null;
+
         try {
             Member member = optionalMember.get();
-            response = ResponseEntity.ok(member);
+            responseBody = ApiResponse.createSuccessResponse(member);
+            response = ResponseEntity.ok(responseBody);
         } catch (NoSuchElementException exception) {
-            response = ResponseEntity.notFound().build();
+            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, exception.getLocalizedMessage());
+            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
         }
 
         return response;
     }
 
     @GetMapping("/members")
-    ResponseEntity<List<Member>> findMembers() {
+    ResponseEntity<ApiResponse<List<Member>>> findMembers() {
         List<Member> members = memberRepository.findAll();
-        return ResponseEntity.ok(members);
+        ApiResponse<List<Member>> responseBody = ApiResponse.createSuccessResponse(members);
+        return ResponseEntity.ok(responseBody);
     }
 
     /*
@@ -47,9 +53,10 @@ public class MemberController {
         ISSUE: 수정 시 코드의 반복을 막기 위해 패턴 도입이 필요해보임.
      */
     @PatchMapping("/members/{id}")
-    ResponseEntity<Object> updateMemberInfo(@PathVariable("id") Long id, @RequestBody Member member) {
+    ResponseEntity<ApiResponse<Member>> updateMemberInfo(@PathVariable("id") Long id, @RequestBody Member member) {
         Optional<Member> optionalMember = memberRepository.findById(id);
-        ResponseEntity<Object> response = null;
+        ResponseEntity<ApiResponse<Member>> response = null;
+        ApiResponse<Member> responseBody = null;
 
         if (optionalMember.isPresent()) {
             Member findMember = optionalMember.get();
@@ -58,9 +65,11 @@ public class MemberController {
             findMember.setIntro(member.getIntro());
 
             memberRepository.save(findMember);
-            response = ResponseEntity.ok(findMember);
+            responseBody = ApiResponse.createSuccessResponse(findMember);
+            response = ResponseEntity.ok(ApiResponse.createSuccessResponse(findMember));
         } else {
-            response = ResponseEntity.notFound().build();
+            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND);
+            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
         }
 
         return response;
@@ -70,16 +79,19 @@ public class MemberController {
         TODO: 자격증명하여 인가된 사용자만 호출할 수 있도록 해야함
      */
     @DeleteMapping("/members/{id}")
-    ResponseEntity<Object> deleteMember(@PathVariable("id") Long id) {
+    ResponseEntity<ApiResponse<Member>> deleteMember(@PathVariable("id") Long id) {
         Optional<Member> optionalMember = memberRepository.findById(id);
-        ResponseEntity<Object> response = null;
+        ResponseEntity<ApiResponse<Member>> response = null;
+        ApiResponse<Member> responseBody = null;
 
         if (optionalMember.isPresent()) {
             Member findMember = optionalMember.get();
             memberRepository.delete(findMember);
-            response = ResponseEntity.ok(findMember);
+            responseBody = ApiResponse.createSuccessResponse(findMember);
+            response = ResponseEntity.ok(responseBody);
         } else {
-            response = ResponseEntity.notFound().build();
+            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND);
+            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
         }
 
         return response;

--- a/src/main/java/com/example/blog/utils/ApiResponse.java
+++ b/src/main/java/com/example/blog/utils/ApiResponse.java
@@ -1,0 +1,53 @@
+package com.example.blog.utils;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/*
+    응답 형식 (JSON)
+    {
+      "code": "XXX",
+      "status": "success",
+      "data": {
+        "username": "anonymous",
+        "intro": "some intros"
+      }
+ */
+@Getter
+public class ApiResponse<T> {
+    private int code;
+    private String status;
+    private String message;
+    private T data;
+
+    private final static String SUCCESS_STATUS = "success";
+    private final static String FAILURE_STATUS = "failure";
+
+    private ApiResponse(T data, HttpStatus code, String status, String message) {
+        this.code = code.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    private ApiResponse(T data, HttpStatus code, String status) {
+        this(data, code, status, null);
+    }
+
+
+    public static <T> ApiResponse<T> createSuccessResponse(T data) {
+        return new ApiResponse<>(data, HttpStatus.OK, SUCCESS_STATUS);
+    }
+
+    public static <T> ApiResponse<T> createSuccessResponse(T data, HttpStatus statusCode) {
+        return new ApiResponse<>(data, statusCode, SUCCESS_STATUS);
+    }
+
+    public static <T> ApiResponse<T> createFailureResponse(T data, HttpStatus statusCode) {
+        return new ApiResponse<>(data, statusCode, FAILURE_STATUS);
+    }
+
+    public static <T> ApiResponse<T> createFailureResponse(T data, HttpStatus statusCode, String additionalMessage) {
+        return new ApiResponse<>(data, statusCode, FAILURE_STATUS, additionalMessage);
+    }
+}


### PR DESCRIPTION
- 반환하려는 응답을 `ApiResponse` 객체로 생성해 `ResponseEntity`의 `body`에 삽입하여 HTTP 응답을 규격화합니다.
- HTTP 응답 코드는 `ApiResponse`와 `ResponseEntity` 모두 설정해주어야 합니다.
- `ApiResponse`는 제너릭으로 데이터를 받기 때문에 어떤 객체든 담아낼 수 있습니다.