### PR TITLE
feat: 회원 조회, 중복 예외처리

### DIFF
--- a/src/main/java/com/example/blog/controller/LoginController.java
+++ b/src/main/java/com/example/blog/controller/LoginController.java
@@ -1,11 +1,13 @@
 package com.example.blog.controller;
 
+import com.example.blog.exception.MemberDuplicatedException;
 import com.example.blog.model.Member;
 import com.example.blog.repository.MemberRepository;
 import com.example.blog.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,13 +28,12 @@ public class LoginController {
 
         if (findMember == null) {
             Member savedMember = memberRepository.save(member);
-            String uriString = new StringBuilder().append("/members").append(savedMember.getId()).toString();
+            String uriString = new StringBuffer().append("/members").append(savedMember.getId()).toString();
             URI location = URI.create(uriString);
             responseBody = ApiResponse.createSuccessResponse(savedMember, HttpStatus.CREATED);
             response = ResponseEntity.created(location).body(responseBody);
         } else {
-            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.BAD_REQUEST);
-            response = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
+            throw new MemberDuplicatedException();
         }
 
         return response;

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.example.blog.controller;
 
+import com.example.blog.exception.MemberNotFoundException;
 import com.example.blog.model.Member;
 import com.example.blog.repository.MemberRepository;
 import com.example.blog.utils.ApiResponse;
@@ -29,8 +30,7 @@ public class MemberController {
             responseBody = ApiResponse.createSuccessResponse(member);
             response = ResponseEntity.ok(responseBody);
         } catch (NoSuchElementException exception) {
-            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, exception.getLocalizedMessage());
-            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+            throw new MemberNotFoundException();
         }
 
         return response;
@@ -68,8 +68,7 @@ public class MemberController {
             responseBody = ApiResponse.createSuccessResponse(findMember);
             response = ResponseEntity.ok(ApiResponse.createSuccessResponse(findMember));
         } else {
-            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND);
-            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+            throw new MemberNotFoundException();
         }
 
         return response;
@@ -90,8 +89,7 @@ public class MemberController {
             responseBody = ApiResponse.createSuccessResponse(findMember);
             response = ResponseEntity.ok(responseBody);
         } else {
-            responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND);
-            response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+            throw new MemberNotFoundException();
         }
 
         return response;

--- a/src/main/java/com/example/blog/exception/MemberDuplicatedException.java
+++ b/src/main/java/com/example/blog/exception/MemberDuplicatedException.java
@@ -1,0 +1,25 @@
+package com.example.blog.exception;
+
+public class MemberDuplicatedException extends RuntimeException {
+    private static final String message = "사용자 이름이 중복 되었습니다.";
+
+    public MemberDuplicatedException() {
+        super(message);
+    }
+
+    public MemberDuplicatedException(String message) {
+        super(message);
+    }
+
+    public MemberDuplicatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberDuplicatedException(Throwable cause) {
+        super(cause);
+    }
+
+    protected MemberDuplicatedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/example/blog/exception/MemberNotFoundException.java
+++ b/src/main/java/com/example/blog/exception/MemberNotFoundException.java
@@ -1,0 +1,25 @@
+package com.example.blog.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+    private static final String message = "존재하지 않는 사용자입니다.";
+
+    public MemberNotFoundException() {
+        super(message);
+    }
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    protected MemberNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/example/blog/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/example/blog/handler/MemberExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.blog.handler;
+
+import com.example.blog.exception.MemberDuplicatedException;
+import com.example.blog.exception.MemberNotFoundException;
+import com.example.blog.model.Member;
+import com.example.blog.utils.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MemberExceptionHandler {
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<Member>> handleDuplicatedMember(MemberDuplicatedException e) {
+        ApiResponse<Member> responseBody = ApiResponse.createFailureResponse(null, HttpStatus.CONFLICT, e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(responseBody);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<Member>> handleMemberNotFound(MemberNotFoundException e) {
+        ApiResponse<Member> responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+    }
+}


### PR DESCRIPTION
- @RestControllerAdvice를 활용한 전역적 예외 처리
- 회원 조회 및 중복시 발생하는 예외를 처리. 기본 생성자로 생성했을 때 메시지가 저장되도록 함.