### PR TITLE
10 feature api 응답 객체 간소화

### DIFF
--- a/src/main/java/com/example/blog/controller/LoginController.java
+++ b/src/main/java/com/example/blog/controller/LoginController.java
@@ -1,15 +1,11 @@
 package com.example.blog.controller;
 
-import com.example.blog.exception.MemberDuplicatedException;
 import com.example.blog.model.dto.MemberDto;
-import com.example.blog.model.entity.Member;
-import com.example.blog.repository.MemberRepository;
 import com.example.blog.service.MemberService;
 import com.example.blog.utils.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,20 +16,12 @@ import java.net.URI;
 @RequiredArgsConstructor
 public class LoginController {
 
-    private final MemberRepository memberRepository;
     private final MemberService memberService;
 
     @PostMapping("/register")
-    ResponseEntity<ApiResponse<Member>> createMember(@Valid @RequestBody MemberDto dto) {
+    ApiResponse<MemberDto> createMember(@Valid @RequestBody MemberDto dto) {
         memberService.checkDuplication(dto);
-        ResponseEntity<ApiResponse<Member>> response = null;
-        ApiResponse<Member> responseBody = null;
-
-        Member savedMember = memberService.postMember(dto);
-        URI location = URI.create("/members" + savedMember.getId());
-        responseBody = ApiResponse.createSuccessResponse(savedMember, HttpStatus.CREATED);
-        response = ResponseEntity.created(location).body(responseBody);
-
-        return response;
+        MemberDto savedMemberDto = memberService.post(dto);
+        return ApiResponse.createSuccessResponse(savedMemberDto, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -25,27 +26,17 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/{id}")
-    ResponseEntity<ApiResponse<Member>> findMemberById(@PathVariable("id") Long id) {
-        Optional<Member> optionalMember = memberRepository.findById(id);
-        ResponseEntity<ApiResponse<Member>> response = null;
-        ApiResponse<Member> responseBody = null;
-
-        try {
-            Member member = optionalMember.get();
-            responseBody = ApiResponse.createSuccessResponse(member);
-            response = ResponseEntity.ok(responseBody);
-        } catch (NoSuchElementException exception) {
-            throw new MemberNotFoundException();
-        }
-
-        return response;
+    ApiResponse<MemberDto> findMemberById(@PathVariable("id") Long id) {
+        Member member = memberService.find(id);
+        MemberDto dto = MemberMapper.toDto(member);
+        return ApiResponse.createSuccessResponse(dto);
     }
 
     @GetMapping
-    ResponseEntity<ApiResponse<List<Member>>> findMembers() {
+    ApiResponse<List<MemberDto>> findMembers() {
         List<Member> members = memberRepository.findAll();
-        ApiResponse<List<Member>> responseBody = ApiResponse.createSuccessResponse(members);
-        return ResponseEntity.ok(responseBody);
+        List<MemberDto> dtos = MemberMapper.toDtos(members);
+        return ApiResponse.createSuccessResponse(dtos);
     }
 
     /*
@@ -54,33 +45,21 @@ public class MemberController {
         - Ex. 비밀번호를 제외한 필드를 수정
      */
     @PatchMapping("/{id}")
-    ResponseEntity<ApiResponse<MemberDto>> updateMemberInfo(
+    ApiResponse<MemberDto> updateMemberInfo(
             @PathVariable("id") Long id, @Valid @RequestBody MemberDto memberDto
     ) {
-        Member updatedMember = memberService.updateMember(id, memberDto);
+        Member updatedMember = memberService.update(id, memberDto);
         MemberDto responseDto = MemberMapper.toDto(updatedMember);
-        return ResponseEntity.ok(ApiResponse.createSuccessResponse(responseDto));
+        return ApiResponse.createSuccessResponse(responseDto);
     }
 
     /*
         TODO: 자격증명하여 인가된 사용자만 호출할 수 있도록 해야함
      */
     @DeleteMapping("/{id}")
-    ResponseEntity<ApiResponse<Member>> deleteMember(@PathVariable("id") Long id) {
-        Optional<Member> optionalMember = memberRepository.findById(id);
-        ResponseEntity<ApiResponse<Member>> response = null;
-        ApiResponse<Member> responseBody = null;
-
-        if (optionalMember.isPresent()) {
-            Member findMember = optionalMember.get();
-            memberRepository.delete(findMember);
-            responseBody = ApiResponse.createSuccessResponse(findMember);
-            response = ResponseEntity.ok(responseBody);
-        } else {
-            throw new MemberNotFoundException();
-        }
-
-        return response;
-
+    ApiResponse<MemberDto> deleteMember(@PathVariable("id") Long id) {
+        Member deletedMember = memberService.delete(id);
+        MemberDto dto = MemberMapper.toDto(deletedMember);
+        return ApiResponse.createSuccessResponse(dto);
     }
 }

--- a/src/main/java/com/example/blog/model/dto/MemberDto.java
+++ b/src/main/java/com/example/blog/model/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.example.blog.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -13,6 +14,7 @@ public class MemberDto {
     @Size(min = 2, max = 50, message = "사용자 이름은 2글자에서 50글자 사이여야 합니다.")
     private String username;
 
+    @JsonIgnore
     @NotNull(message = "비밀번호가 누락되었습니다.")
     @Size(min = 4, max = 20, message = "비밀번호는 4글자에서 20글자 사이여야 합니다.")
     private String password;

--- a/src/main/java/com/example/blog/model/dto/MemberDto.java
+++ b/src/main/java/com/example/blog/model/dto/MemberDto.java
@@ -1,6 +1,7 @@
 package com.example.blog.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -14,7 +15,7 @@ public class MemberDto {
     @Size(min = 2, max = 50, message = "사용자 이름은 2글자에서 50글자 사이여야 합니다.")
     private String username;
 
-    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @NotNull(message = "비밀번호가 누락되었습니다.")
     @Size(min = 4, max = 20, message = "비밀번호는 4글자에서 20글자 사이여야 합니다.")
     private String password;

--- a/src/main/java/com/example/blog/model/mapper/MemberMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/MemberMapper.java
@@ -3,6 +3,9 @@ package com.example.blog.model.mapper;
 import com.example.blog.model.dto.MemberDto;
 import com.example.blog.model.entity.Member;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MemberMapper {
     public static Member toEntity(MemberDto dto) {
         Member member = new Member();
@@ -21,8 +24,16 @@ public class MemberMapper {
         dto.setId(member.getId());
         dto.setUsername(member.getUsername());
         dto.setPassword(member.getPassword());
-        dto.setId(member.getId());
+        dto.setIntro(member.getIntro());
 
         return dto;
+    }
+
+    public static List<MemberDto> toDtos(List<Member> members) {
+        List<MemberDto> dtos = new ArrayList<>();
+        for (Member member: members) {
+            dtos.add(MemberMapper.toDto(member));
+        }
+        return dtos;
     }
 }

--- a/src/main/java/com/example/blog/service/MemberService.java
+++ b/src/main/java/com/example/blog/service/MemberService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -23,20 +24,34 @@ public class MemberService {
         }
     }
 
-    @Transactional
-    public Member updateMember(Long id, MemberDto memberDto) {
-        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+    public Member delete(Long id) {
+        Member member = this.find(id);
+        memberRepository.deleteById(member.getId());
+        return member;
+    }
+
+    public Member find(Long id) {
+        return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+    }
+
+    public MemberDto post(MemberDto dto) {
+        Member member = MemberMapper.toEntity(dto);
+        member = memberRepository.save(member);
+        // debate
+        // - MemberMapper.toDto는 내부적으로 new를 사용해 객체를 생성한다. 오버헤드는 없을까?
+        // - 이 메서드가 실행될 때, Member와 MemberDto가 다른 점은 영속성 컨텍스트로부터 받아온 id가 존재하는지 아닌지이다. setter를 사용해 id만 변경하는건 어떨까?
+        dto = MemberMapper.toDto(member);
+
+        return dto;
+    }
+
+    public Member update(Long id, MemberDto memberDto) {
+        Member member = this.find(id);
 
         member.setUsername(memberDto.getUsername());
         member.setPassword(memberDto.getPassword());
         member.setIntro(memberDto.getIntro());
 
-        return member;
-    }
-
-    public Member postMember(MemberDto dto) {
-        Member member = MemberMapper.toEntity(dto);
-        member = memberRepository.save(member);
         return member;
     }
 }


### PR DESCRIPTION
**MemberController**
- 기존 `ResponseEntity<ApiResponse<>>` 와 같이 응답하던 컨트롤러 응답을 모두 `ApiResponse<>` 객체로 변경했습니다.

**MemberService**
- 서비스 계층의 메서드를 호출할 때, Dto가 필요한 경우에만 Dto를 전달하도록 했습니다.
- `MemberService.checkDuplication()`의 경우 문자열(`username`)만 필요하니 String만을 전달해도 되지만, 중복의 개념이 추후 변경될 수 있기 때문에 Dto를 전달하도록 했습니다.

**MemberMapper**
- `List<Member>` -> `List<MemberDto>`로 변경해주는 메서드를 추가했습니다.

**MemberDto**
- `MemberDto`가 반환될 때 `password` 필드의 반환을 막기 위해 어노테이션을 추가했습니다.