### PR TITLE
12 feature 게시물 crud api 작성

### DIFF
--- a/init-scripts/init.sql
+++ b/init-scripts/init.sql
@@ -28,6 +28,10 @@ CREATE TABLE comment (
                          CONSTRAINT comment_article_fk FOREIGN KEY (article_id) REFERENCES article(article_id) ON DELETE CASCADE
 );
 
-INSERT INTO member(username, password, intro) VALUES('test1', '12345', '안녕하세요. 테스트1입니다.');
-INSERT INTO member(username, password, intro) VALUES('test2', '12345', '안녕하세요. 테스트2입니다.');
-INSERT INTO member(username, password, intro) VALUES('test3', '12345', '안녕하세요. 테스트3입니다.');
+INSERT INTO member(username, password, intro) VALUES('test1', '12345', 'This is test1');
+INSERT INTO member(username, password, intro) VALUES('test2', '12345', 'This is test2');
+INSERT INTO member(username, password, intro) VALUES('test3', '12345', 'This is test3');
+
+INSERT INTO article(member_id, title, contents) VALUES(1, 'Article1: this is first article.', 'This is the contents of the first article.');
+INSERT INTO article(member_id, title, contents) VALUES(2, 'Article2: this is first article.', 'This is the contents of the first article.');
+INSERT INTO article(member_id, title, contents) VALUES(3, 'Article3: this is first article.', 'This is the contents of the first article.');

--- a/init-scripts/init.sql
+++ b/init-scripts/init.sql
@@ -8,7 +8,9 @@ CREATE TABLE member (
                         member_id BIGINT AUTO_INCREMENT PRIMARY KEY,
                         username VARCHAR(50) NOT NULL,
                         password VARCHAR(255) NOT NULL,
-                        intro VARCHAR(255)
+                        intro VARCHAR(255),
+                        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE article (
@@ -16,6 +18,8 @@ CREATE TABLE article (
                          member_id BIGINT NOT NULL,
                          title VARCHAR(255) NOT NULL,
                          contents TEXT NOT NULL,
+                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                          CONSTRAINT article_member_fk FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE CASCADE
 );
 
@@ -24,14 +28,96 @@ CREATE TABLE comment (
                          member_id BIGINT NOT NULL,
                          article_id BIGINT NOT NULL,
                          contents VARCHAR(511) NOT NULL,
+                         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                          CONSTRAINT comment_member_fk FOREIGN KEY(member_id) REFERENCES member(member_id) ON DELETE CASCADE,
                          CONSTRAINT comment_article_fk FOREIGN KEY (article_id) REFERENCES article(article_id) ON DELETE CASCADE
 );
 
-INSERT INTO member(username, password, intro) VALUES('test1', '12345', 'This is test1');
-INSERT INTO member(username, password, intro) VALUES('test2', '12345', 'This is test2');
-INSERT INTO member(username, password, intro) VALUES('test3', '12345', 'This is test3');
+-- INSERT INTO member(username, password, intro) VALUES('test1', '12345', 'This is test1');
+-- INSERT INTO member(username, password, intro) VALUES('test2', '12345', 'This is test2');
+-- INSERT INTO member(username, password, intro) VALUES('test3', '12345', 'This is test3');
+--
+-- INSERT INTO article(member_id, title, contents) VALUES(1, 'Article1: this is first article.', 'This is the contents of the first article.');
+-- INSERT INTO article(member_id, title, contents) VALUES(2, 'Article2: this is first article.', 'This is the contents of the first article.');
+-- INSERT INTO article(member_id, title, contents) VALUES(3, 'Article3: this is first article.', 'This is the contents of the first article.');
+--
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(1, 1, 'Comment about article1 - by member 1');
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(2, 1, 'Comment about article1 - by member 2');
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(3, 1, 'Comment about article1 - by member 3');
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(1, 2, 'Comment about article2 - by member 1');
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(2, 2, 'Comment about article2 - by member 2');
+-- INSERT INTO comment(member_id, article_id, contents) VALUES(3, 2, 'Comment about article2 - by member 3');
 
-INSERT INTO article(member_id, title, contents) VALUES(1, 'Article1: this is first article.', 'This is the contents of the first article.');
-INSERT INTO article(member_id, title, contents) VALUES(2, 'Article2: this is first article.', 'This is the contents of the first article.');
-INSERT INTO article(member_id, title, contents) VALUES(3, 'Article3: this is first article.', 'This is the contents of the first article.');
+-- 회원 데이터 삽입
+INSERT INTO member (username, password, intro) VALUES
+                                                   ('user1', 'password1', 'intro for user1'),
+                                                   ('user2', 'password2', 'intro for user2'),
+                                                   ('user3', 'password3', 'intro for user3'),
+                                                   ('user4', 'password4', 'intro for user4'),
+                                                   ('user5', 'password5', 'intro for user5');
+
+-- 게시글 데이터 삽입
+DELIMITER $$
+
+CREATE PROCEDURE insert_articles()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    DECLARE j INT DEFAULT 1;
+    DECLARE memberId INT;
+
+    -- 5명의 회원에 대해 각 회원당 50개의 게시글을 생성
+    WHILE i <= 5 DO
+        SET memberId = i;
+        WHILE j <= 50 DO
+            INSERT INTO article (member_id, title, contents) VALUES
+            (memberId, CONCAT('Title ', j, ' for user', i), CONCAT('Contents for article ', j, ' by user', i));
+            SET j = j + 1;
+END WHILE;
+        SET i = i + 1;
+        SET j = 1;
+END WHILE;
+
+    -- 특정 게시글 (1번 게시글)에 100개의 댓글 추가
+    SET j = 1;
+    WHILE j <= 100 DO
+        INSERT INTO comment (member_id, article_id, contents) VALUES
+        (FLOOR(1 + (RAND() * 5)), 1, CONCAT('Comment ', j, ' for article 1'));
+        SET j = j + 1;
+END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_articles();
+
+-- 댓글 데이터 삽입 (각 게시글에 10개 이하의 댓글 추가)
+DELIMITER $$
+
+CREATE PROCEDURE insert_comments()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    DECLARE j INT DEFAULT 1;
+    DECLARE k INT DEFAULT 1;
+    DECLARE totalArticles INT;
+
+    -- 전체 게시글 수를 조회
+SELECT COUNT(*) INTO totalArticles FROM article;
+
+-- 각 게시글에 대해 10개 이하의 댓글을 추가
+WHILE i <= totalArticles DO
+        SET j = FLOOR(1 + (RAND() * 10));
+        SET k = 1;
+        WHILE k <= j DO
+            INSERT INTO comment (member_id, article_id, contents) VALUES
+            (FLOOR(1 + (RAND() * 5)), i, CONCAT('Comment ', k, ' for article ', i));
+            SET k = k + 1;
+END WHILE;
+        SET i = i + 1;
+END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_comments();
+

--- a/src/main/java/com/example/blog/BlogApplication.java
+++ b/src/main/java/com/example/blog/BlogApplication.java
@@ -2,8 +2,10 @@ package com.example.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BlogApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/blog/controller/ArticleController.java
+++ b/src/main/java/com/example/blog/controller/ArticleController.java
@@ -3,6 +3,7 @@ package com.example.blog.controller;
 import com.example.blog.model.dto.ArticleDto;
 import com.example.blog.service.ArticleService;
 import com.example.blog.utils.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,17 @@ public class ArticleController {
     @GetMapping("/{id}")
     public ApiResponse<ArticleDto> findOne(@PathVariable(name = "id") Long id) {
         return ApiResponse.createSuccessResponse(articleService.findById(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<ArticleDto> remove(@PathVariable(name = "id") Long id) {
+        return ApiResponse.createSuccessResponse(articleService.delete(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<ArticleDto> updateOne(@PathVariable(name = "id") Long id, @Valid @RequestBody ArticleDto dto) {
+        dto.setId(id);
+        return ApiResponse.createSuccessResponse(articleService.update(dto));
     }
 
     @PostMapping()

--- a/src/main/java/com/example/blog/controller/ArticleController.java
+++ b/src/main/java/com/example/blog/controller/ArticleController.java
@@ -1,7 +1,10 @@
 package com.example.blog.controller;
 
 import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.ArticleResponseDto;
+import com.example.blog.model.dto.CommentResponseDto;
 import com.example.blog.service.ArticleService;
+import com.example.blog.service.CommentService;
 import com.example.blog.utils.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,31 +19,32 @@ import java.util.List;
 public class ArticleController {
 
     private final ArticleService articleService;
-
-    @GetMapping
-    public ApiResponse<List<ArticleDto>> findAll() {
-        List<ArticleDto> result = articleService.findAll();
-        return ApiResponse.createSuccessResponse(result);
-    }
+    private final CommentService commentService;
 
     @GetMapping("/{id}")
-    public ApiResponse<ArticleDto> findOne(@PathVariable(name = "id") Long id) {
+    public ApiResponse<ArticleResponseDto> findOne(@PathVariable(name = "id") Long id) {
         return ApiResponse.createSuccessResponse(articleService.findById(id));
     }
 
     @DeleteMapping("/{id}")
-    public ApiResponse<ArticleDto> remove(@PathVariable(name = "id") Long id) {
+    public ApiResponse<ArticleResponseDto> remove(@PathVariable(name = "id") Long id) {
         return ApiResponse.createSuccessResponse(articleService.delete(id));
     }
 
     @PatchMapping("/{id}")
-    public ApiResponse<ArticleDto> updateOne(@PathVariable(name = "id") Long id, @Valid @RequestBody ArticleDto dto) {
+    public ApiResponse<ArticleResponseDto> updateOne(@PathVariable(name = "id") Long id, @Valid @RequestBody ArticleDto dto) {
         dto.setId(id);
         return ApiResponse.createSuccessResponse(articleService.update(dto));
     }
 
     @PostMapping()
-    public ApiResponse<ArticleDto> write(@RequestBody ArticleDto dto) {
+    public ApiResponse<ArticleResponseDto> write(@RequestBody ArticleDto dto) {
         return ApiResponse.createSuccessResponse(articleService.post(dto), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}/comments")
+    public ApiResponse<List<CommentResponseDto>> findCommentsOnArticle(@PathVariable(name = "id") Long id) {
+        List<CommentResponseDto> dtos = commentService.findAllOnArticle(id);
+        return ApiResponse.createSuccessResponse(dtos);
     }
 }

--- a/src/main/java/com/example/blog/controller/ArticleController.java
+++ b/src/main/java/com/example/blog/controller/ArticleController.java
@@ -23,7 +23,7 @@ public class ArticleController {
 
     @GetMapping("/{id}")
     public ApiResponse<ArticleResponseDto> findOne(@PathVariable(name = "id") Long id) {
-        return ApiResponse.createSuccessResponse(articleService.findById(id));
+        return ApiResponse.createSuccessResponse(articleService.findByIdAsDto(id));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/blog/controller/ArticleController.java
+++ b/src/main/java/com/example/blog/controller/ArticleController.java
@@ -1,0 +1,34 @@
+package com.example.blog.controller;
+
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.service.ArticleService;
+import com.example.blog.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/articles")
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @GetMapping
+    public ApiResponse<List<ArticleDto>> findAll() {
+        List<ArticleDto> result = articleService.findAll();
+        return ApiResponse.createSuccessResponse(result);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<ArticleDto> findOne(@PathVariable(name = "id") Long id) {
+        return ApiResponse.createSuccessResponse(articleService.findById(id));
+    }
+
+    @PostMapping()
+    public ApiResponse<ArticleDto> write(@RequestBody ArticleDto dto) {
+        return ApiResponse.createSuccessResponse(articleService.post(dto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/example/blog/controller/CommentController.java
+++ b/src/main/java/com/example/blog/controller/CommentController.java
@@ -1,0 +1,35 @@
+package com.example.blog.controller;
+
+import com.example.blog.exception.ArticleNotFoundException;
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.CommentDto;
+import com.example.blog.model.dto.CommentResponseDto;
+import com.example.blog.model.entity.Article;
+import com.example.blog.model.mapper.ArticleMapper;
+import com.example.blog.repository.ArticleRepository;
+import com.example.blog.repository.CommentRepository;
+import com.example.blog.service.ArticleService;
+import com.example.blog.service.CommentService;
+import com.example.blog.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+    private final ArticleRepository articleRepository;
+
+    @GetMapping("/comments/{id}")
+    public ApiResponse<CommentResponseDto> findOne(@PathVariable(name = ("id")) Long id) {
+        CommentResponseDto dto = commentService.findById(id);
+        return ApiResponse.createSuccessResponse(dto);
+    }
+
+}

--- a/src/main/java/com/example/blog/controller/CommentController.java
+++ b/src/main/java/com/example/blog/controller/CommentController.java
@@ -1,9 +1,7 @@
 package com.example.blog.controller;
 
 import com.example.blog.exception.ArticleNotFoundException;
-import com.example.blog.model.dto.ArticleDto;
-import com.example.blog.model.dto.CommentDto;
-import com.example.blog.model.dto.CommentResponseDto;
+import com.example.blog.model.dto.*;
 import com.example.blog.model.entity.Article;
 import com.example.blog.model.mapper.ArticleMapper;
 import com.example.blog.repository.ArticleRepository;
@@ -11,11 +9,10 @@ import com.example.blog.repository.CommentRepository;
 import com.example.blog.service.ArticleService;
 import com.example.blog.service.CommentService;
 import com.example.blog.utils.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,12 +21,38 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
-    private final ArticleRepository articleRepository;
+
+    @PostMapping("/comments")
+    public ApiResponse<CommentResponseDto> postComment(@Valid @RequestBody CommentPostRequestDto requestDto) {
+        CommentResponseDto responseDto = commentService.post(requestDto);
+        return ApiResponse.createSuccessResponse(responseDto, HttpStatus.CREATED);
+    }
 
     @GetMapping("/comments/{id}")
     public ApiResponse<CommentResponseDto> findOne(@PathVariable(name = ("id")) Long id) {
         CommentResponseDto dto = commentService.findById(id);
         return ApiResponse.createSuccessResponse(dto);
+    }
+
+    @PatchMapping("/comments/{id}")
+    public ApiResponse<CommentResponseDto> updateComment(@PathVariable(name = "id") Long id, @Valid @RequestBody CommentPatchRequestDto requestDto) {
+        CommentResponseDto responseDto = commentService.update(id, requestDto);
+        return ApiResponse.createSuccessResponse(responseDto);
+    }
+
+    @DeleteMapping("/comments/{id}")
+    public ApiResponse<Integer> deleteComment(@PathVariable(name = "id") Long id) {
+        int deleted;
+        ApiResponse<Integer> response;
+        try {
+            deleted = commentService.delete(id);
+            response = ApiResponse.createSuccessResponse(deleted);
+        } catch (Exception e) {
+            deleted = 0;
+            response = ApiResponse.createSuccessResponse(deleted, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return response;
     }
 
 }

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -27,8 +27,7 @@ public class MemberController {
 
     @GetMapping("/{id}")
     ApiResponse<MemberDto> findMemberById(@PathVariable("id") Long id) {
-        Member member = memberService.find(id);
-        MemberDto dto = MemberMapper.toDto(member);
+        MemberDto dto = memberService.findById(id);
         return ApiResponse.createSuccessResponse(dto);
     }
 
@@ -48,8 +47,7 @@ public class MemberController {
     ApiResponse<MemberDto> updateMemberInfo(
             @PathVariable("id") Long id, @Valid @RequestBody MemberDto memberDto
     ) {
-        Member updatedMember = memberService.update(id, memberDto);
-        MemberDto responseDto = MemberMapper.toDto(updatedMember);
+        MemberDto responseDto = memberService.update(id, memberDto);
         return ApiResponse.createSuccessResponse(responseDto);
     }
 
@@ -58,8 +56,7 @@ public class MemberController {
      */
     @DeleteMapping("/{id}")
     ApiResponse<MemberDto> deleteMember(@PathVariable("id") Long id) {
-        Member deletedMember = memberService.delete(id);
-        MemberDto dto = MemberMapper.toDto(deletedMember);
+        MemberDto dto = memberService.delete(id);
         return ApiResponse.createSuccessResponse(dto);
     }
 }

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
 
     @GetMapping("/{id}")
     ApiResponse<MemberDto> findMemberById(@PathVariable("id") Long id) {
-        MemberDto dto = memberService.findById(id);
+        MemberDto dto = memberService.findByIdAsDto(id);
         return ApiResponse.createSuccessResponse(dto);
     }
 

--- a/src/main/java/com/example/blog/controller/MemberController.java
+++ b/src/main/java/com/example/blog/controller/MemberController.java
@@ -1,10 +1,15 @@
 package com.example.blog.controller;
 
+import com.example.blog.model.dto.ArticleResponseDto;
+import com.example.blog.model.dto.CommentDto;
+import com.example.blog.model.dto.CommentResponseDto;
 import com.example.blog.model.dto.MemberDto;
 import com.example.blog.exception.MemberNotFoundException;
 import com.example.blog.model.entity.Member;
 import com.example.blog.model.mapper.MemberMapper;
 import com.example.blog.repository.MemberRepository;
+import com.example.blog.service.ArticleService;
+import com.example.blog.service.CommentService;
 import com.example.blog.service.MemberService;
 import com.example.blog.utils.ApiResponse;
 import jakarta.validation.Valid;
@@ -24,18 +29,20 @@ public class MemberController {
 
     private final MemberRepository memberRepository;
     private final MemberService memberService;
-
-    @GetMapping("/{id}")
-    ApiResponse<MemberDto> findMemberById(@PathVariable("id") Long id) {
-        MemberDto dto = memberService.findById(id);
-        return ApiResponse.createSuccessResponse(dto);
-    }
+    private final ArticleService articleService;
+    private final CommentService commentService;
 
     @GetMapping
     ApiResponse<List<MemberDto>> findMembers() {
         List<Member> members = memberRepository.findAll();
         List<MemberDto> dtos = MemberMapper.toDtos(members);
         return ApiResponse.createSuccessResponse(dtos);
+    }
+
+    @GetMapping("/{id}")
+    ApiResponse<MemberDto> findMemberById(@PathVariable("id") Long id) {
+        MemberDto dto = memberService.findById(id);
+        return ApiResponse.createSuccessResponse(dto);
     }
 
     /*
@@ -58,5 +65,17 @@ public class MemberController {
     ApiResponse<MemberDto> deleteMember(@PathVariable("id") Long id) {
         MemberDto dto = memberService.delete(id);
         return ApiResponse.createSuccessResponse(dto);
+    }
+
+    @GetMapping("/{id}/articles")
+    public ApiResponse<List<ArticleResponseDto>> findArticlesOnMember(@PathVariable(name = "id") Long id) {
+        List<ArticleResponseDto> result = articleService.findAll(id);
+        return ApiResponse.createSuccessResponse(result);
+    }
+
+    @GetMapping("/{id}/comments")
+    public ApiResponse<List<CommentResponseDto>> findCommentsOnMember(@PathVariable(name = "id") Long id) {
+        List<CommentResponseDto> comments = commentService.findAllOnMember(id);
+        return ApiResponse.createSuccessResponse(comments);
     }
 }

--- a/src/main/java/com/example/blog/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/example/blog/exception/ArticleNotFoundException.java
@@ -1,0 +1,24 @@
+package com.example.blog.exception;
+
+public class ArticleNotFoundException extends RuntimeException{
+    private static final String MESSAGE = "게시글을 찾을 수 없습니다.";
+    public ArticleNotFoundException() {
+        super(MESSAGE);
+    }
+
+    public ArticleNotFoundException(String message) {
+        super(message);
+    }
+
+    public ArticleNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ArticleNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    protected ArticleNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/example/blog/exception/CommentNotFoundException.java
+++ b/src/main/java/com/example/blog/exception/CommentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.blog.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    private final static String MESSAGE = "댓글을 찾을 수 없습니다.";
+    public CommentNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/blog/handler/ArticleExceptionHandler.java
+++ b/src/main/java/com/example/blog/handler/ArticleExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.example.blog.handler;
+
+import com.example.blog.exception.ArticleNotFoundException;
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.utils.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ArticleExceptionHandler {
+    @ExceptionHandler
+    public ApiResponse<ArticleDto> handleArticleNotFound(ArticleNotFoundException e) {
+        return ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, e.getMessage());
+    }
+}

--- a/src/main/java/com/example/blog/handler/GeneralExceptionHandler.java
+++ b/src/main/java/com/example/blog/handler/GeneralExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.example.blog.handler;
+
+import com.example.blog.utils.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GeneralExceptionHandler {
+
+    @ExceptionHandler
+    public ApiResponse<?> handleGeneralException(Exception ex) {
+        return ApiResponse.createFailureResponse(null, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+}

--- a/src/main/java/com/example/blog/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/example/blog/handler/MemberExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.example.blog.handler;
 
+import com.example.blog.exception.ArticleNotFoundException;
 import com.example.blog.exception.MemberDuplicatedException;
 import com.example.blog.exception.MemberNotFoundException;
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.MemberDto;
 import com.example.blog.model.entity.Member;
 import com.example.blog.utils.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -13,21 +16,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class MemberExceptionHandler {
     @ExceptionHandler
-    public ResponseEntity<ApiResponse<Member>> handleDuplicatedMember(MemberDuplicatedException e) {
-        ApiResponse<Member> responseBody = ApiResponse.createFailureResponse(null, HttpStatus.CONFLICT, e.getMessage());
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(responseBody);
+    public ApiResponse<MemberDto> handleDuplicatedMember(MemberDuplicatedException e) {
+        return ApiResponse.createFailureResponse(null, HttpStatus.CONFLICT, e.getMessage());
     }
 
     @ExceptionHandler
-    public ResponseEntity<ApiResponse<Member>> handleMemberNotFound(MemberNotFoundException e) {
-        ApiResponse<Member> responseBody = ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, e.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+    public ApiResponse<MemberDto> handleMemberNotFound(MemberNotFoundException e) {
+        return ApiResponse.createFailureResponse(null, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler
-    public ResponseEntity<ApiResponse<Member>> handleValidationViolation(MethodArgumentNotValidException e) {
+    public ApiResponse<MemberDto> handleValidationViolation(MethodArgumentNotValidException e) {
         String simpleErrorMessage = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
-        ApiResponse<Member> responseBody = ApiResponse.createFailureResponse(null, HttpStatus.BAD_REQUEST, simpleErrorMessage);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
+        return ApiResponse.createFailureResponse(null, HttpStatus.BAD_REQUEST, simpleErrorMessage);
     }
+
 }

--- a/src/main/java/com/example/blog/model/dto/ArticleDto.java
+++ b/src/main/java/com/example/blog/model/dto/ArticleDto.java
@@ -1,5 +1,8 @@
 package com.example.blog.model.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +15,13 @@ import lombok.Setter;
 public class ArticleDto {
     private Long id;
     private Long memberId;
+
+    @NotNull(message = "제목은 없을 수 없습니다.")
+    @NotBlank(message = "제목은 공백일 수 없습니다.")
+    @Size(max = 255)
     private String title;
+
+    @NotNull(message = "본문의 내용은 없을 수 없습니다.")
+    @Size(max = 20_000, message = "본문의 내용은 20000글자 이하여야 합니다.")
     private String contents;
 }

--- a/src/main/java/com/example/blog/model/dto/ArticleDto.java
+++ b/src/main/java/com/example/blog/model/dto/ArticleDto.java
@@ -1,0 +1,17 @@
+package com.example.blog.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleDto {
+    private Long id;
+    private Long memberId;
+    private String title;
+    private String contents;
+}

--- a/src/main/java/com/example/blog/model/dto/ArticleEmbeddedResponseDto.java
+++ b/src/main/java/com/example/blog/model/dto/ArticleEmbeddedResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.blog.model.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ArticleEmbeddedResponseDto {
+    /**
+     * 임베딩 된 본문 내용에 포함될 내용
+     * ArticleID, ArticleCreatedAt, ArticleUpdatedAt, ArticleTitle
+     */
+    private Long id;
+    private String title;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ArticleEmbeddedResponseDto(Long id, String title, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/blog/model/dto/ArticleResponseDto.java
+++ b/src/main/java/com/example/blog/model/dto/ArticleResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.blog.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ArticleResponseDto {
+    private Long id;
+    // TODO: 회원 반환값을 MemberDto로 변환(이름, memberId)
+    private Long memberId;
+    private String title;
+    private String contents;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/com/example/blog/model/dto/CommentDto.java
+++ b/src/main/java/com/example/blog/model/dto/CommentDto.java
@@ -1,0 +1,12 @@
+package com.example.blog.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CommentDto {
+
+    private Long id;
+    private MemberDto memberDto;
+    private String contents;
+
+}

--- a/src/main/java/com/example/blog/model/dto/CommentPatchRequestDto.java
+++ b/src/main/java/com/example/blog/model/dto/CommentPatchRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.blog.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentPatchRequestDto {
+    @NotNull
+    Long memberId;
+
+    @NotNull
+    @NotBlank
+    String contents;
+}

--- a/src/main/java/com/example/blog/model/dto/CommentPostRequestDto.java
+++ b/src/main/java/com/example/blog/model/dto/CommentPostRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.blog.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentPostRequestDto {
+    @NotNull
+    Long memberId;
+
+    @NotNull
+    Long articleId;
+
+    @NotNull
+    @NotBlank
+    String contents;
+}

--- a/src/main/java/com/example/blog/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/blog/model/dto/CommentResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.blog.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CommentResponseDto {
+    private Long id;
+    private ArticleEmbeddedResponseDto article;
+    private MemberEmbeddedResponseDto member;
+    private String contents;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/blog/model/dto/MemberDto.java
+++ b/src/main/java/com/example/blog/model/dto/MemberDto.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberDto {
 
     private Long id;

--- a/src/main/java/com/example/blog/model/dto/MemberEmbeddedResponseDto.java
+++ b/src/main/java/com/example/blog/model/dto/MemberEmbeddedResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.blog.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberEmbeddedResponseDto {
+    private Long id;
+    private String username;
+
+    public MemberEmbeddedResponseDto(Long id, String username) {
+        this.id = id;
+        this.username = username;
+    }
+}

--- a/src/main/java/com/example/blog/model/entity/Article.java
+++ b/src/main/java/com/example/blog/model/entity/Article.java
@@ -1,0 +1,44 @@
+package com.example.blog.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article")
+@Getter
+@NoArgsConstructor
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String title;
+
+    private String contents;
+
+    public Article(
+            Long id, String title, String contents
+    ) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public Article (
+            Long id,
+            Member member,
+            String title,
+            String contents
+    ) {
+        this.id = id;
+        this.member = member;
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/example/blog/model/entity/Article.java
+++ b/src/main/java/com/example/blog/model/entity/Article.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Entity
 @Table(name = "article")
 @Getter
 @Setter
 @NoArgsConstructor
-public class Article {
+public class Article extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "article_id")

--- a/src/main/java/com/example/blog/model/entity/Article.java
+++ b/src/main/java/com/example/blog/model/entity/Article.java
@@ -1,12 +1,15 @@
 package com.example.blog.model.entity;
 
+import com.example.blog.model.dto.ArticleDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "article")
 @Getter
+@Setter
 @NoArgsConstructor
 public class Article {
     @Id
@@ -40,5 +43,13 @@ public class Article {
         this.member = member;
         this.title = title;
         this.contents = contents;
+    }
+
+    /**
+     * 작성자가 변경될 일이 없기 때문에 member는 변경하지 않음
+     */
+    public void updateTitleAndContents(ArticleDto dto) {
+        this.title = dto.getTitle();
+        this.contents = dto.getContents();
     }
 }

--- a/src/main/java/com/example/blog/model/entity/BaseEntity.java
+++ b/src/main/java/com/example/blog/model/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.example.blog.model.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/blog/model/entity/Comment.java
+++ b/src/main/java/com/example/blog/model/entity/Comment.java
@@ -1,0 +1,27 @@
+package com.example.blog.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@Setter
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    private String contents;
+}

--- a/src/main/java/com/example/blog/model/entity/Comment.java
+++ b/src/main/java/com/example/blog/model/entity/Comment.java
@@ -1,5 +1,7 @@
 package com.example.blog.model.entity;
 
+import com.example.blog.model.dto.CommentPatchRequestDto;
+import com.example.blog.model.dto.CommentPostRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,4 +26,8 @@ public class Comment extends BaseEntity {
     private Article article;
 
     private String contents;
+
+    public void updateContents(CommentPatchRequestDto dto) {
+        this.contents = dto.getContents();
+    }
 }

--- a/src/main/java/com/example/blog/model/entity/Member.java
+++ b/src/main/java/com/example/blog/model/entity/Member.java
@@ -1,13 +1,19 @@
 package com.example.blog.model.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @Table(name = "member")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Member {
     @Id
     @Column(name = "member_id")

--- a/src/main/java/com/example/blog/model/entity/Member.java
+++ b/src/main/java/com/example/blog/model/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -13,8 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-public class Member {
+public class Member extends BaseEntity {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,4 +22,14 @@ public class Member {
     String username;
     String password;
     String intro;
+
+    @OneToMany(mappedBy = "member")
+    List<Article> articles = new ArrayList<>();
+
+    public Member(Long id, String username, String password, String intro) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.intro = intro;
+    }
 }

--- a/src/main/java/com/example/blog/model/mapper/ArticleMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/ArticleMapper.java
@@ -1,0 +1,28 @@
+package com.example.blog.model.mapper;
+
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.MemberDto;
+import com.example.blog.model.entity.Article;
+import com.example.blog.model.entity.Member;
+
+public class ArticleMapper {
+    public static Article toEntity(ArticleDto dto, MemberDto memberDto) {
+        if (dto == null) {
+            return null;
+        }
+        Member member = MemberMapper.toEntity(memberDto);
+        return new Article(dto.getId(), member, dto.getTitle(), dto.getContents());
+    }
+
+    public static ArticleDto toDto(Article article) {
+        if (article == null) {
+            return null;
+        }
+        return new ArticleDto(
+                article.getId(),
+                article.getMember().getId(),
+                article.getTitle(),
+                article.getContents()
+        );
+    }
+}

--- a/src/main/java/com/example/blog/model/mapper/ArticleMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/ArticleMapper.java
@@ -1,6 +1,8 @@
 package com.example.blog.model.mapper;
 
 import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.ArticleEmbeddedResponseDto;
+import com.example.blog.model.dto.ArticleResponseDto;
 import com.example.blog.model.dto.MemberDto;
 import com.example.blog.model.entity.Article;
 import com.example.blog.model.entity.Member;
@@ -23,6 +25,34 @@ public class ArticleMapper {
                 article.getMember().getId(),
                 article.getTitle(),
                 article.getContents()
+        );
+    }
+
+    public static ArticleResponseDto toResponseDto(Article article) {
+        if (article == null) {
+            return null;
+        }
+
+        return new ArticleResponseDto(
+                article.getId(),
+                article.getMember().getId(),
+                article.getTitle(),
+                article.getContents(),
+                article.getCreatedAt(),
+                article.getUpdatedAt()
+        );
+    }
+
+    public static ArticleEmbeddedResponseDto toEmbeddedResponseDto(Article article) {
+        if (article == null) {
+            return null;
+        }
+
+        return new ArticleEmbeddedResponseDto(
+                article.getId(),
+                article.getTitle(),
+                article.getCreatedAt(),
+                article.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/example/blog/model/mapper/CommentMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/CommentMapper.java
@@ -6,6 +6,14 @@ import com.example.blog.model.entity.Member;
 
 public class CommentMapper {
 
+    public static Comment toEntity(CommentPostRequestDto dto) {
+        Comment comment = new Comment();
+
+        comment.setContents(dto.getContents());
+
+        return comment;
+    }
+
     public static CommentDto toDto(Comment comment) {
         CommentDto dto = new CommentDto();
 

--- a/src/main/java/com/example/blog/model/mapper/CommentMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/CommentMapper.java
@@ -1,0 +1,35 @@
+package com.example.blog.model.mapper;
+
+import com.example.blog.model.dto.*;
+import com.example.blog.model.entity.Comment;
+import com.example.blog.model.entity.Member;
+
+public class CommentMapper {
+
+    public static CommentDto toDto(Comment comment) {
+        CommentDto dto = new CommentDto();
+
+        dto.setId(comment.getId());
+        dto.setContents(comment.getContents());
+
+        MemberDto memberDto = MemberMapper.toDto(comment.getMember());
+        dto.setMemberDto(memberDto);
+
+        return dto;
+    }
+
+    public static CommentResponseDto toResponseDto(Comment comment) {
+        CommentResponseDto dto = new CommentResponseDto();
+
+        MemberEmbeddedResponseDto memberDto = MemberMapper.toEmbeddedResponseDto(comment.getMember());
+        ArticleEmbeddedResponseDto articleDto = ArticleMapper.toEmbeddedResponseDto(comment.getArticle());
+        dto.setId(comment.getId());
+        dto.setMember(memberDto);
+        dto.setCreatedAt(comment.getCreatedAt());
+        dto.setUpdatedAt(comment.getUpdatedAt());
+        dto.setArticle(articleDto);
+        dto.setContents(comment.getContents());
+
+        return dto;
+    }
+}

--- a/src/main/java/com/example/blog/model/mapper/MemberMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.example.blog.model.mapper;
 
 import com.example.blog.model.dto.MemberDto;
+import com.example.blog.model.dto.MemberEmbeddedResponseDto;
 import com.example.blog.model.entity.Member;
 
 import java.util.ArrayList;
@@ -35,6 +36,15 @@ public class MemberMapper {
                 member.getIntro()
         );
 
+    }
+
+    public static MemberEmbeddedResponseDto toEmbeddedResponseDto(Member member) {
+
+        if (member == null) {
+            return null;
+        }
+
+        return new MemberEmbeddedResponseDto(member.getId(), member.getUsername());
     }
 
     public static List<MemberDto> toDtos(List<Member> members) {

--- a/src/main/java/com/example/blog/model/mapper/MemberMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/MemberMapper.java
@@ -5,6 +5,7 @@ import com.example.blog.model.entity.Member;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class MemberMapper {
     public static Member toEntity(MemberDto dto) {
@@ -30,10 +31,6 @@ public class MemberMapper {
     }
 
     public static List<MemberDto> toDtos(List<Member> members) {
-        List<MemberDto> dtos = new ArrayList<>();
-        for (Member member: members) {
-            dtos.add(MemberMapper.toDto(member));
-        }
-        return dtos;
+        return members.stream().map(MemberMapper::toDto).toList();
     }
 }

--- a/src/main/java/com/example/blog/model/mapper/MemberMapper.java
+++ b/src/main/java/com/example/blog/model/mapper/MemberMapper.java
@@ -9,28 +9,39 @@ import java.util.stream.Stream;
 
 public class MemberMapper {
     public static Member toEntity(MemberDto dto) {
-        Member member = new Member();
 
-        member.setId(dto.getId());
-        member.setUsername(dto.getUsername());
-        member.setPassword(dto.getPassword());
-        member.setIntro(dto.getIntro());
+        if (dto == null) {
+            return null;
+        }
 
-        return member;
+        return new Member(
+                dto.getId(),
+                dto.getUsername(),
+                dto.getPassword(),
+                dto.getIntro()
+        );
     }
 
     public static MemberDto toDto(Member member) {
-        MemberDto dto = new MemberDto();
 
-        dto.setId(member.getId());
-        dto.setUsername(member.getUsername());
-        dto.setPassword(member.getPassword());
-        dto.setIntro(member.getIntro());
+        if (member == null) {
+            return null;
+        }
 
-        return dto;
+        return new MemberDto(
+                member.getId(),
+                member.getUsername(),
+                member.getPassword(),
+                member.getIntro()
+        );
+
     }
 
     public static List<MemberDto> toDtos(List<Member> members) {
+        if (members == null) {
+            return null;
+        }
+
         return members.stream().map(MemberMapper::toDto).toList();
     }
 }

--- a/src/main/java/com/example/blog/repository/ArticleRepository.java
+++ b/src/main/java/com/example/blog/repository/ArticleRepository.java
@@ -2,6 +2,14 @@ package com.example.blog.repository;
 
 import com.example.blog.model.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    @Query("select a from Article a inner join a.member m where m.id=:memberId")
+    List<Article> findArticlesByMemberId(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/example/blog/repository/ArticleRepository.java
+++ b/src/main/java/com/example/blog/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.example.blog.repository;
+
+import com.example.blog.model.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/example/blog/repository/CommentRepository.java
+++ b/src/main/java/com/example/blog/repository/CommentRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("select c from Comment c join c.article a where a.id=:articleId")
+    @Query("select c from Comment c join fetch c.article a where a.id=:articleId")
     List<Comment> findCommentsByArticleId(@Param("articleId") Long articleId);
 
     @Query("select c from Comment c join c.member m where m.id=:memberId")

--- a/src/main/java/com/example/blog/repository/CommentRepository.java
+++ b/src/main/java/com/example/blog/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.example.blog.repository;
+
+import com.example.blog.model.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c from Comment c join c.article a where a.id=:articleId")
+    List<Comment> findCommentsByArticleId(@Param("articleId") Long articleId);
+
+    @Query("select c from Comment c join c.member m where m.id=:memberId")
+    List<Comment> findCommentsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/blog/service/ArticleService.java
+++ b/src/main/java/com/example/blog/service/ArticleService.java
@@ -38,8 +38,12 @@ public class ArticleService {
         return articles.stream().map(ArticleMapper::toResponseDto).toList();
     }
 
-    public ArticleResponseDto findById(Long id) {
-        Article article = articleRepository.findById(id).orElseThrow(ArticleNotFoundException::new);
+    public Article findById(Long id) {
+        return this.find(id);
+    }
+
+    public ArticleResponseDto findByIdAsDto(Long id) {
+        Article article = this.find(id);
         return ArticleMapper.toResponseDto(article);
     }
 
@@ -61,7 +65,7 @@ public class ArticleService {
     }
 
     private MemberDto getMemberDto(ArticleDto dto) {
-        return memberService.findById(dto.getMemberId());
+        return memberService.findByIdAsDto(dto.getMemberId());
     }
 
     private Article find(Long id) {

--- a/src/main/java/com/example/blog/service/ArticleService.java
+++ b/src/main/java/com/example/blog/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.example.blog.service;
 
 import com.example.blog.exception.ArticleNotFoundException;
 import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.ArticleResponseDto;
 import com.example.blog.model.dto.MemberDto;
 import com.example.blog.model.entity.Article;
 import com.example.blog.model.mapper.ArticleMapper;
@@ -21,20 +22,49 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final MemberService memberService;
 
-    public List<ArticleDto> findAll() {
+    public ArticleResponseDto delete(Long id) {
+        Article article = this.find(id);
+        articleRepository.delete(article);
+        return ArticleMapper.toResponseDto(article);
+    }
+
+    public List<ArticleResponseDto> findAll() {
         List<Article> articles = articleRepository.findAll();
-        return articles.stream().map(ArticleMapper::toDto).toList();
+        return articles.stream().map(ArticleMapper::toResponseDto).toList();
     }
 
-    public ArticleDto findById(Long id) {
-        Optional<Article> articleOptional = articleRepository.findById(id);
-        return ArticleMapper.toDto(articleOptional.orElseThrow(ArticleNotFoundException::new));
+    public List<ArticleResponseDto> findAll(Long memberId) {
+        List<Article> articles = articleRepository.findArticlesByMemberId(memberId);
+        return articles.stream().map(ArticleMapper::toResponseDto).toList();
     }
 
-    public ArticleDto post(ArticleDto dto) {
-        MemberDto memberDto = memberService.findById(dto.getMemberId());
+    public ArticleResponseDto findById(Long id) {
+        Article article = articleRepository.findById(id).orElseThrow(ArticleNotFoundException::new);
+        return ArticleMapper.toResponseDto(article);
+    }
+
+    /**
+     * 수정하려는 Article Entity의 member는 변경되지 않습니다.
+     */
+    public ArticleResponseDto update(ArticleDto dto) {
+        Article article = this.find(dto.getId());
+        article.updateTitleAndContents(dto);
+        articleRepository.saveAndFlush(article);
+        return ArticleMapper.toResponseDto(article);
+    }
+
+    public ArticleResponseDto post(ArticleDto dto) {
+        MemberDto memberDto = getMemberDto(dto);
         Article article = ArticleMapper.toEntity(dto, memberDto);
-        articleRepository.save(article);
-        return ArticleMapper.toDto(article);
+        article = articleRepository.save(article);
+        return ArticleMapper.toResponseDto(article);
+    }
+
+    private MemberDto getMemberDto(ArticleDto dto) {
+        return memberService.findById(dto.getMemberId());
+    }
+
+    private Article find(Long id) {
+        return articleRepository.findById(id).orElseThrow(ArticleNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/blog/service/ArticleService.java
+++ b/src/main/java/com/example/blog/service/ArticleService.java
@@ -1,0 +1,40 @@
+package com.example.blog.service;
+
+import com.example.blog.exception.ArticleNotFoundException;
+import com.example.blog.model.dto.ArticleDto;
+import com.example.blog.model.dto.MemberDto;
+import com.example.blog.model.entity.Article;
+import com.example.blog.model.mapper.ArticleMapper;
+import com.example.blog.repository.ArticleRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final MemberService memberService;
+
+    public List<ArticleDto> findAll() {
+        List<Article> articles = articleRepository.findAll();
+        return articles.stream().map(ArticleMapper::toDto).toList();
+    }
+
+    public ArticleDto findById(Long id) {
+        Optional<Article> articleOptional = articleRepository.findById(id);
+        return ArticleMapper.toDto(articleOptional.orElseThrow(ArticleNotFoundException::new));
+    }
+
+    public ArticleDto post(ArticleDto dto) {
+        MemberDto memberDto = memberService.findById(dto.getMemberId());
+        Article article = ArticleMapper.toEntity(dto, memberDto);
+        articleRepository.save(article);
+        return ArticleMapper.toDto(article);
+    }
+}

--- a/src/main/java/com/example/blog/service/CommentService.java
+++ b/src/main/java/com/example/blog/service/CommentService.java
@@ -1,0 +1,37 @@
+package com.example.blog.service;
+
+import com.example.blog.exception.CommentNotFoundException;
+import com.example.blog.model.dto.CommentDto;
+import com.example.blog.model.dto.CommentResponseDto;
+import com.example.blog.model.entity.Comment;
+import com.example.blog.model.mapper.CommentMapper;
+import com.example.blog.repository.CommentRepository;
+import com.example.blog.utils.ApiResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    public CommentResponseDto findById(Long id) {
+        Comment comment = commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
+        return CommentMapper.toResponseDto(comment);
+    }
+
+    public List<CommentResponseDto> findAllOnArticle(Long articleId) {
+        List<Comment> commentsByArticleId = commentRepository.findCommentsByArticleId(articleId);
+        return commentsByArticleId.stream().map(CommentMapper::toResponseDto).toList();
+    }
+
+    public List<CommentResponseDto> findAllOnMember(Long memberId) {
+        List<Comment> comments = commentRepository.findCommentsByMemberId(memberId);
+        return comments.stream().map(CommentMapper::toResponseDto).toList();
+    }
+}

--- a/src/main/java/com/example/blog/service/CommentService.java
+++ b/src/main/java/com/example/blog/service/CommentService.java
@@ -1,12 +1,14 @@
 package com.example.blog.service;
 
 import com.example.blog.exception.CommentNotFoundException;
-import com.example.blog.model.dto.CommentDto;
+import com.example.blog.model.dto.CommentPatchRequestDto;
+import com.example.blog.model.dto.CommentPostRequestDto;
 import com.example.blog.model.dto.CommentResponseDto;
+import com.example.blog.model.entity.Article;
 import com.example.blog.model.entity.Comment;
+import com.example.blog.model.entity.Member;
 import com.example.blog.model.mapper.CommentMapper;
 import com.example.blog.repository.CommentRepository;
-import com.example.blog.utils.ApiResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,14 @@ import java.util.List;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final ArticleService articleService;
+    private final MemberService memberService;
+
+    public int delete(Long id) {
+        Comment comment = this.find(id);
+        commentRepository.delete(comment); // Exception 처리 고려
+        return 1;
+    }
 
     public CommentResponseDto findById(Long id) {
         Comment comment = commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
@@ -33,5 +43,29 @@ public class CommentService {
     public List<CommentResponseDto> findAllOnMember(Long memberId) {
         List<Comment> comments = commentRepository.findCommentsByMemberId(memberId);
         return comments.stream().map(CommentMapper::toResponseDto).toList();
+    }
+
+    public CommentResponseDto post(CommentPostRequestDto dto) {
+        Comment comment = CommentMapper.toEntity(dto);
+        Article article = articleService.findById(dto.getArticleId());
+        Member member = memberService.findById(dto.getMemberId());
+
+        comment.setMember(member);
+        comment.setArticle(article);
+
+        commentRepository.saveAndFlush(comment);
+
+        return CommentMapper.toResponseDto(comment);
+    }
+
+    public CommentResponseDto update(Long id, CommentPatchRequestDto dto) {
+        Comment comment = this.find(id);
+        comment.updateContents(dto);
+        commentRepository.saveAndFlush(comment);
+        return CommentMapper.toResponseDto(comment); // 이 과정에서 Member, Article에 접근해서 추가 쿼리가 발생.
+    }
+
+    private Comment find(Long id) {
+        return commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/blog/service/MemberService.java
+++ b/src/main/java/com/example/blog/service/MemberService.java
@@ -24,14 +24,19 @@ public class MemberService {
         }
     }
 
-    public Member delete(Long id) {
+    public MemberDto delete(Long id) {
         Member member = this.find(id);
         memberRepository.deleteById(member.getId());
-        return member;
+        return MemberMapper.toDto(member);
     }
 
-    public Member find(Long id) {
-        return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+    public MemberDto findById(Long id) {
+        Member findMember = this.find(id);
+        return MemberMapper.toDto(findMember);
+    }
+
+    public MemberDto findByName(String username) {
+        return MemberMapper.toDto(memberRepository.findByUsername(username));
     }
 
     public MemberDto post(MemberDto dto) {
@@ -45,13 +50,17 @@ public class MemberService {
         return dto;
     }
 
-    public Member update(Long id, MemberDto memberDto) {
+    public MemberDto update(Long id, MemberDto memberDto) {
         Member member = this.find(id);
 
         member.setUsername(memberDto.getUsername());
         member.setPassword(memberDto.getPassword());
         member.setIntro(memberDto.getIntro());
 
-        return member;
+        return MemberMapper.toDto(memberRepository.save(member));
+    }
+
+    private Member find(Long id) {
+        return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/blog/service/MemberService.java
+++ b/src/main/java/com/example/blog/service/MemberService.java
@@ -30,7 +30,11 @@ public class MemberService {
         return MemberMapper.toDto(member);
     }
 
-    public MemberDto findById(Long id) {
+    public Member findById(Long id) {
+        return this.find(id);
+    }
+
+    public MemberDto findByIdAsDto(Long id) {
         Member findMember = this.find(id);
         return MemberMapper.toDto(findMember);
     }


### PR DESCRIPTION
**게시물 CRUD와 댓글 CRUD API 작성했습니다**

** 작업내용 **
- `BaseEntity` 구현 및 상속하여 모든 엔티티가 생성일시와 수정일시를 가지도록 했습니다.
- 댓글이나 게시물을 GET할 때 그것에 관련된 연관관계 엔티티를 추가적으로 반환할 수 있도록 DTO를 설계했습니다. `CommentResponseDto`, `ArticleResponseDto` 등

** 개선사항 **
- GET `/articles/{id}/comments` 를 수행할 때 N+1 문제가 발생합니다. 
- DTO의 개수가 많은데, 명확한 네이밍을 통해 그것들의 책임을 정확히 분리하는 작업이 필요할 것 같습니다.